### PR TITLE
Run in Docker container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+.next
+.vscode
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,39 +1,14 @@
-FROM node:18-alpine AS deps
-RUN apk add --no-cache libc6-compat
+FROM node:18-alpine as builder
 WORKDIR /app
-
-COPY package.json package-lock.json ./
-RUN npm ci 
-
-# Rebuild the source code only when needed
-FROM node:18-alpine AS builder
-WORKDIR /app
-
 COPY . .
-COPY --from=deps /app/node_modules ./node_modules
-
-ENV NEXT_TELEMETRY_DISABLED 1
-
+RUN npm install --include=dev
 RUN npm run build
 
 FROM node:18-alpine AS runner
 WORKDIR /app
-
-ENV NODE_ENV production
-ENV NEXT_TELEMETRY_DISABLED 1
-
-RUN addgroup --system --gid 1001 nodejs
-RUN adduser --system --uid 1001 nextjs
-
-COPY --from=builder --chown=nextjs:nodejs /app/.next ./.next
-COPY --from=builder /app/node_modules ./node_modules
-COPY --from=builder /app/package.json ./package.json
+COPY --from=builder /app/.next/standalone .
 COPY --from=builder /app/public ./public
-
-USER nextjs
+COPY --from=builder /app/.next/static ./.next/static
 
 EXPOSE 3000
-
-ENV PORT 3000
-
-CMD ["npm", "start"]
+CMD ["node", "server.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+FROM node:18-alpine AS deps
+RUN apk add --no-cache libc6-compat
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci 
+
+# Rebuild the source code only when needed
+FROM node:18-alpine AS builder
+WORKDIR /app
+
+COPY . .
+COPY --from=deps /app/node_modules ./node_modules
+
+ENV NEXT_TELEMETRY_DISABLED 1
+
+RUN npm run build
+
+FROM node:18-alpine AS runner
+WORKDIR /app
+
+ENV NODE_ENV production
+ENV NEXT_TELEMETRY_DISABLED 1
+
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 nextjs
+
+COPY --from=builder --chown=nextjs:nodejs /app/.next ./.next
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/package.json ./package.json
+COPY --from=builder /app/public ./public
+
+USER nextjs
+
+EXPOSE 3000
+
+ENV PORT 3000
+
+CMD ["npm", "start"]

--- a/next.config.js
+++ b/next.config.js
@@ -5,6 +5,7 @@ const nextConfig = {
   // building the app. Since pdfjs-dist is only used on client side, we disable
   // the canvas package for webpack
   // https://github.com/mozilla/pdf.js/issues/16214
+  output: 'standalone',
   webpack: (config) => {
     // Setting resolve.alias to false tells webpack to ignore a module
     // https://webpack.js.org/configuration/resolve/#resolvealias


### PR DESCRIPTION
Fixes #8 

1. Build the container with `docker build -t open-resume .` 
2. Run it with `docker run -p 3000:3000 open-resume` 
3. Browse to http://localhost:3000 

I get about a 877.14 MB image, I'm not too familiar with Node so this could potentially be optimized in the future.

