### PR TITLE
Fix unable to scale manually on the first click

### DIFF
--- a/src/app/components/Resume/hooks.tsx
+++ b/src/app/components/Resume/hooks.tsx
@@ -48,9 +48,8 @@ export const useSetDefaultScale = ({
       setScale(defaultScale);
     };
 
-    setDefaultScale();
-
     if (scaleOnResize) {
+      setDefaultScale();
       window.addEventListener("resize", setDefaultScale);
     }
 


### PR DESCRIPTION
When the `autoscale` is enabled. Clicking the slider won't immediately change the scale.