### PR TITLE
Skip bullet points on empty lines

### DIFF
--- a/src/app/components/Resume/ResumePDF/common/index.tsx
+++ b/src/app/components/Resume/ResumePDF/common/index.tsx
@@ -96,7 +96,7 @@ export const ResumePDFBulletList = ({
               }}
               bold={true}
             >
-              {"•"}
+              {item !== "" ? "•" : ""}
             </ResumePDFText>
           )}
           {/* A breaking change was introduced causing text layout to be wider than node's width


### PR DESCRIPTION
## Change
Add conditional to only render a bullet point when there is text to show

## Reason for change
Empty bullet points make the document look unprofessional.

This additionally provides a short term method of adding additional spacing (ex: placing a few empty job entries to add padding near a page break) while margin [styles seem to be ignored ](https://github.com/xitanggg/open-resume/issues/41)