### PR TITLE
Multi-page layout

### DIFF
--- a/src/app/components/Resume/ResumePDF/ResumePDFCustom.tsx
+++ b/src/app/components/Resume/ResumePDF/ResumePDFCustom.tsx
@@ -20,7 +20,7 @@ export const ResumePDFCustom = ({
   const { descriptions } = custom;
 
   return (
-    <ResumePDFSection themeColor={themeColor} heading={heading}>
+    <ResumePDFSection themeColor={themeColor} heading={heading} wrap={false}>
       <View style={{ ...styles.flexCol }}>
         <ResumePDFBulletList
           items={descriptions}

--- a/src/app/components/Resume/ResumePDF/ResumePDFEducation.tsx
+++ b/src/app/components/Resume/ResumePDF/ResumePDFEducation.tsx
@@ -19,7 +19,7 @@ export const ResumePDFEducation = ({
   showBulletPoints: boolean;
 }) => {
   return (
-    <ResumePDFSection themeColor={themeColor} heading={heading}>
+    <ResumePDFSection themeColor={themeColor} heading={heading} wrap={false}>
       {educations.map(
         ({ school, degree, date, gpa, descriptions = [] }, idx) => {
           // Hide school name if it is the same as the previous school

--- a/src/app/components/Resume/ResumePDF/ResumePDFProject.tsx
+++ b/src/app/components/Resume/ResumePDF/ResumePDFProject.tsx
@@ -17,7 +17,7 @@ export const ResumePDFProject = ({
   themeColor: string;
 }) => {
   return (
-    <ResumePDFSection themeColor={themeColor} heading={heading}>
+    <ResumePDFSection themeColor={themeColor} heading={heading} wrap={false}>
       {projects.map(({ project, date, descriptions }, idx) => (
         <View key={idx}>
           <View

--- a/src/app/components/Resume/ResumePDF/ResumePDFSkills.tsx
+++ b/src/app/components/Resume/ResumePDF/ResumePDFSkills.tsx
@@ -27,7 +27,7 @@ export const ResumePDFSkills = ({
   ];
 
   return (
-    <ResumePDFSection themeColor={themeColor} heading={heading}>
+    <ResumePDFSection themeColor={themeColor} heading={heading} wrap={false}>
       {featuredSkillsWithText.length > 0 && (
         <View style={{ ...styles.flexRowBetween, marginTop: spacing["0.5"] }}>
           {featuredSkillsPair.map((pair, idx) => (

--- a/src/app/components/Resume/ResumePDF/ResumePDFWorkExperience.tsx
+++ b/src/app/components/Resume/ResumePDF/ResumePDFWorkExperience.tsx
@@ -24,7 +24,7 @@ export const ResumePDFWorkExperience = ({
           idx > 0 && company === workExperiences[idx - 1].company;
 
         return (
-          <View key={idx} style={idx !== 0 ? { marginTop: spacing["2"] } : {}}>
+          <View wrap={false} key={idx} style={idx !== 0 ? { marginTop: spacing["2"] } : {}}>
             {!hideCompanyName && (
               <ResumePDFText bold={true}>{company}</ResumePDFText>
             )}

--- a/src/app/components/Resume/ResumePDF/common/index.tsx
+++ b/src/app/components/Resume/ResumePDF/common/index.tsx
@@ -9,13 +9,16 @@ export const ResumePDFSection = ({
   heading,
   style = {},
   children,
+  wrap,
 }: {
   themeColor?: string;
   heading?: string;
   style?: Style;
   children: React.ReactNode;
+  wrap?: boolean;
 }) => (
   <View
+    wrap={wrap}
     style={{
       ...styles.flexCol,
       gap: spacing["2"],


### PR DESCRIPTION
This is an attempt to fix multi-page resumes.

**TL;DR**: Do not split companies and sections other than work experience when moving them to a new page.

My idea behind this is that work experience is usually the longest section in the resume, so we only move its subsections (companies) to a new page when it does not fit. Other sections are relatively small so we can move the whole section to a new page when it does not fit.

Screenshots for reference: 
1. When work experience does not fit in 1 page:  
<img width="546" alt="Screenshot 2023-09-07 at 13 49 37" src="https://github.com/xitanggg/open-resume/assets/5795653/59bbbb25-07a4-456a-ae38-3765edbfbd35">  

2. When other sections do not fit in 1 page:  
<img width="554" alt="Screenshot 2023-09-07 at 13 49 51" src="https://github.com/xitanggg/open-resume/assets/5795653/04c7af97-fc84-4234-85a7-55742eeb4848">  

3. Possible problem when the work experience heading gets split on the second page. It can only occur when people move work experience to be not the first section. I do not think this is critical:  
<img width="550" alt="Screenshot 2023-09-07 at 13 48 58" src="https://github.com/xitanggg/open-resume/assets/5795653/2c94f6ce-914d-4381-8ed6-5c1732f258f7">  

4. Another problem is that we do not split anything into a new page on live preview (in production without the debug flag set). The best solution in my opinion would be to introduce a multi-page live preview. But that is out of the scope of this task. One possible change would be to cut out of the live preview all the content that should be on the second page in the resulting PDF. I am not sure about it though.

Let me know what you think about this, I am open to suggestions.
