### PR TITLE
Fix spacing dropped between TextItems

### DIFF
--- a/src/app/lib/parse-resume-from-pdf/group-text-items-into-lines.ts
+++ b/src/app/lib/parse-resume-from-pdf/group-text-items-into-lines.ts
@@ -20,7 +20,7 @@ export const groupTextItemsIntoLines = (textItems: TextItems): Lines => {
       line = [];
     }
     // Otherwise, add item to current line
-    else if (item.text.trim() !== "") {
+    else if (item.text.trim() !== "" || item.text === " ") {
       line.push({ ...item });
     }
   }

--- a/src/app/lib/parse-resume-from-pdf/read-pdf.ts
+++ b/src/app/lib/parse-resume-from-pdf/read-pdf.ts
@@ -82,7 +82,7 @@ export const readPdf = async (fileUrl: string): Promise<TextItems> => {
 
   // Filter out empty space textItem noise
   const isEmptySpace = (textItem: TextItem) =>
-    !textItem.hasEOL && textItem.text.trim() === "";
+    !textItem.hasEOL && textItem.text.trim() === "" && textItem.text !== " ";
   textItems = textItems.filter((textItem) => !isEmptySpace(textItem));
 
   return textItems;


### PR DESCRIPTION
Fixes #106

Certain text formatting causes the adjacent character be in its own `TextItem` from `pdfjs`. This is commonly a space character, which is then dropped by the noise filter, and results in text getting concatenated. I added an exception to the noise filter for a single space to resolve