### PR TITLE
fix: Correct casing for Dockerfile keywords

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine as builder
+FROM node:18-alpine AS builder
 WORKDIR /app
 COPY . .
 RUN npm install --include=dev


### PR DESCRIPTION
Updated the Dockerfile to ensure consistent casing for the 'FROM' and 'AS' keywords, resolving the FromAsCasing warning.