### PR TITLE
Add 'Create from Scratch' Option to Resume Builder for Incomplete Resumes

### DIFF
--- a/src/app/lib/redux/local-storage.ts
+++ b/src/app/lib/redux/local-storage.ts
@@ -1,4 +1,5 @@
-import type { RootState } from "lib/redux/store";
+import { store, type RootState } from "lib/redux/store";
+import { resetResume } from "./resumeSlice";
 
 // Reference: https://dev.to/igorovic/simplest-way-to-persist-redux-state-to-localstorage-e67
 
@@ -18,6 +19,18 @@ export const saveStateToLocalStorage = (state: RootState) => {
   try {
     const stringifiedState = JSON.stringify(state);
     localStorage.setItem(LOCAL_STORAGE_KEY, stringifiedState);
+  } catch (e) {
+    // Ignore
+  }
+};
+
+export const clearLocalStorage = () => {
+  try {
+    localStorage.removeItem(LOCAL_STORAGE_KEY);
+    console.log(localStorage.getItem(LOCAL_STORAGE_KEY),"sss");
+
+    store.dispatch(resetResume());
+    
   } catch (e) {
     // Ignore
   }

--- a/src/app/lib/redux/resumeSlice.ts
+++ b/src/app/lib/redux/resumeSlice.ts
@@ -197,6 +197,7 @@ export const resumeSlice = createSlice({
     setResume: (draft, action: PayloadAction<Resume>) => {
       return action.payload;
     },
+    resetResume: () => initialResumeState,
   },
 });
 
@@ -211,6 +212,7 @@ export const {
   moveSectionInForm,
   deleteSectionInFormByIdx,
   setResume,
+  resetResume,
 } = resumeSlice.actions;
 
 export const selectResume = (state: RootState) => state.resume;

--- a/src/app/resume-import/page.tsx
+++ b/src/app/resume-import/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { getHasUsedAppBefore } from "lib/redux/local-storage";
+import { clearLocalStorage, getHasUsedAppBefore } from "lib/redux/local-storage";
 import { ResumeDropzone } from "components/ResumeDropzone";
 import { useState, useEffect } from "react";
 import Link from "next/link";
@@ -14,6 +14,11 @@ export default function ImportResume() {
   useEffect(() => {
     setHasUsedAppBefore(getHasUsedAppBefore());
   }, []);
+
+  const handleCreateFromScratch = () => {
+    clearLocalStorage(); 
+    setHasAddedResume(false);
+  };
 
   return (
     <main>
@@ -44,6 +49,8 @@ export default function ImportResume() {
                 <SectionWithHeadingAndCreateButton
                   heading="You have data saved in browser from prior session"
                   buttonText="Continue where I left off"
+                  secondaryButtonText="Create from scratch"
+                  onCreateFromScratch={handleCreateFromScratch}
                 />
                 <OrDivider />
               </>
@@ -73,20 +80,33 @@ const OrDivider = () => (
 const SectionWithHeadingAndCreateButton = ({
   heading,
   buttonText,
+  secondaryButtonText,
+  onCreateFromScratch,
 }: {
   heading: string;
   buttonText: string;
+  secondaryButtonText?: string;
+  onCreateFromScratch?: () => void;
 }) => {
   return (
     <>
       <p className="font-semibold text-gray-900">{heading}</p>
-      <div className="mt-5">
+      <div className="mt-5 flex flex-col md:flex-row md:justify-center md:items-center gap-2">
         <Link
           href="/resume-builder"
-          className="outline-theme-blue rounded-full bg-sky-500 px-6 pb-2 pt-1.5 text-base font-semibold text-white"
+          className="block md:inline-block w-full md:w-auto outline-theme-blue rounded-full bg-sky-500 px-6 pb-2 pt-1.5 text-base font-semibold text-white"
         >
           {buttonText}
         </Link>
+        {secondaryButtonText && (
+          <Link
+            href="/resume-builder"
+            onClick={onCreateFromScratch}
+            className="block md:inline-block w-full md:w-auto outline-theme-blue rounded-full bg-sky-500 px-6 pb-2 pt-1.5 text-base font-semibold text-white"
+          >
+            {secondaryButtonText}
+          </Link>
+        )}
       </div>
     </>
   );


### PR DESCRIPTION
This update introduces a new button to the resume builder:

New Button: "Start from Scratch" is added alongside the existing options. This lets users start a new resume if they prefer, while still having the option to continue where they left off or upload an existing resume.

**Key Changes:**
Added "Start from Scratch" button for users who want to begin a new resume.
Updated layout to ensure buttons are centered and responsive on all devices.

**Screenshots:**
![Screenshot 2024-09-14 011649](https://github.com/user-attachments/assets/1e6a0fb0-2058-4aa1-ab2d-b5e33e08af69)

**Testing:**
Verified new button appears and works as expected.
Checked responsive design to ensure proper display on all screen sizes.

Let me know if you have any questions or need further changes!