### PR TITLE
Feat: Add multiple links in Summery #124

### DIFF
--- a/src/app/components/Resume/ResumePDF/ResumePDFProfile.tsx
+++ b/src/app/components/Resume/ResumePDF/ResumePDFProfile.tsx
@@ -20,8 +20,8 @@ export const ResumePDFProfile = ({
   themeColor: string;
   isPDF: boolean;
 }) => {
-  const { name, email, phone, url, summary, location } = profile;
-  const iconProps = { email, phone, location, url };
+  const { name, email, phone, portfolioLink, linkedinLink, githubLink, summary, location } = profile;
+  const iconProps = { email, phone, location,portfolioLink, linkedinLink, githubLink };
 
   return (
     <ResumePDFSection style={{ marginTop: spacing["4"] }}>
@@ -38,21 +38,28 @@ export const ResumePDFProfile = ({
           ...styles.flexRowBetween,
           flexWrap: "wrap",
           marginTop: spacing["0.5"],
+          justifyContent: "center",
+          alignContent: "center",
+          gap:spacing["2.5"],
         }}
       >
         {Object.entries(iconProps).map(([key, value]) => {
           if (!value) return null;
 
           let iconType = key as IconType;
-          if (key === "url") {
-            if (value.includes("github")) {
-              iconType = "url_github";
-            } else if (value.includes("linkedin")) {
+          switch (key) {
+            case "portfolioLink":
+              iconType = "url";
+              break;
+            case "linkedinLink":
               iconType = "url_linkedin";
-            }
+              break;
+            case "githubLink":
+              iconType = "url_github";
+              break;
           }
 
-          const shouldUseLinkWrapper = ["email", "url", "phone"].includes(key);
+          const shouldUseLinkWrapper = ["email", "phone", "portfolioLink", "linkedinLink", "githubLink"].includes(key);
           const Wrapper = ({ children }: { children: React.ReactNode }) => {
             if (!shouldUseLinkWrapper) return <>{children}</>;
 
@@ -64,6 +71,14 @@ export const ResumePDFProfile = ({
               }
               case "phone": {
                 src = `tel:${value.replace(/[^\d+]/g, "")}`; // Keep only + and digits
+                break;
+              }
+              case "linkedinLink": {
+                src = value.startsWith("http") ? value : `https://www.linkedin.com/in/${value}`;
+                break;
+              }
+              case "githubLink": {
+                src = value.startsWith("http") ? value : `https://github.com/${value}`;
                 break;
               }
               default: {
@@ -83,8 +98,8 @@ export const ResumePDFProfile = ({
               key={key}
               style={{
                 ...styles.flexRow,
-                alignItems: "center",
-                gap: spacing["1"],
+                gap: spacing["2"],
+                flex: "0 1 calc(33.333% - 10px)",
               }}
             >
               <ResumePDFIcon type={iconType} isPDF={isPDF} />

--- a/src/app/components/ResumeForm/ProfileForm.tsx
+++ b/src/app/components/ResumeForm/ProfileForm.tsx
@@ -7,7 +7,7 @@ import { ResumeProfile } from "lib/redux/types";
 export const ProfileForm = () => {
   const profile = useAppSelector(selectProfile);
   const dispatch = useAppDispatch();
-  const { name, email, phone, url, summary, location } = profile;
+  const { name, email, phone, summary, location, portfolioLink, linkedinLink, githubLink } = profile;
 
   const handleProfileChange = (field: keyof ResumeProfile, value: string) => {
     dispatch(changeProfile({ field, value }));
@@ -49,11 +49,11 @@ export const ProfileForm = () => {
           onChange={handleProfileChange}
         />
         <Input
-          label="Website"
+          label="Portfolio"
           labelClassName="col-span-4"
-          name="url"
-          placeholder="linkedin.com/in/khanacademy"
-          value={url}
+          name="portfolioLink"
+          placeholder="khanacademy.com"
+          value={portfolioLink}
           onChange={handleProfileChange}
         />
         <Input
@@ -62,6 +62,22 @@ export const ProfileForm = () => {
           name="location"
           placeholder="NYC, NY"
           value={location}
+          onChange={handleProfileChange}
+        />
+        <Input
+          label="LinkedIn Username"
+          labelClassName="col-span-3"
+          name="linkedinLink"
+          placeholder="linkedin.com/in/khanacademy"
+          value={linkedinLink}
+          onChange={handleProfileChange}
+        />
+        <Input
+          label="Github Username"
+          labelClassName="col-span-3"
+          name="githubLink"
+          placeholder="github.com/khanacademy"
+          value={githubLink}
           onChange={handleProfileChange}
         />
       </div>

--- a/src/app/lib/redux/types.ts
+++ b/src/app/lib/redux/types.ts
@@ -2,9 +2,11 @@ export interface ResumeProfile {
   name: string;
   email: string;
   phone: string;
-  url: string;
   summary: string;
   location: string;
+  portfolioLink: string;
+  linkedinLink: string;
+  githubLink: string;
 }
 
 export interface ResumeWorkExperience {


### PR DESCRIPTION
**Requirement:** Add multiple links (LinkedIn, GitHub) in summary

**Support Added:**
1. Added Portfolio, LinkedIn and GitHub links in the summary
2. Removed url from `ResumeProfile` type and introduced `portfolioLink, linkedinLink, githubLink` keys.
3. Modified UI in order to reflect links in the Form.
4. Updated logic to redirect if only username is present.

Updated UI with multiple links -
![image](https://github.com/user-attachments/assets/b09e7836-e06f-4cdc-a864-dccddf63b727)

UI if some links are not there
![image](https://github.com/user-attachments/assets/4d5563db-b28c-45a6-893b-c781c97da5a9)
