### PR TITLE
feat: add URL support for projects, update PDF generation

### DIFF
--- a/src/app/components/Resume/ResumeControlBar.tsx
+++ b/src/app/components/Resume/ResumeControlBar.tsx
@@ -30,7 +30,7 @@ const ResumeControlBar = ({
 
   // Hook to update pdf when document changes
   useEffect(() => {
-    update();
+    update(document);
   }, [update, document]);
 
   return (

--- a/src/app/components/Resume/ResumePDF/ResumePDFProject.tsx
+++ b/src/app/components/Resume/ResumePDF/ResumePDFProject.tsx
@@ -3,22 +3,26 @@ import {
   ResumePDFSection,
   ResumePDFBulletList,
   ResumePDFText,
+  ResumePDFLink,
 } from "components/Resume/ResumePDF/common";
 import { styles, spacing } from "components/Resume/ResumePDF/styles";
 import type { ResumeProject } from "lib/redux/types";
+import { formatUrl } from "./common/utils";
 
 export const ResumePDFProject = ({
   heading,
   projects,
   themeColor,
+  isPDF
 }: {
   heading: string;
   projects: ResumeProject[];
   themeColor: string;
+  isPDF: boolean;
 }) => {
   return (
     <ResumePDFSection themeColor={themeColor} heading={heading}>
-      {projects.map(({ project, date, descriptions }, idx) => (
+      {projects.map(({ project, date, descriptions, url }, idx) => (
         <View key={idx}>
           <View
             style={{
@@ -26,7 +30,13 @@ export const ResumePDFProject = ({
               marginTop: spacing["0.5"],
             }}
           >
-            <ResumePDFText bold={true}>{project}</ResumePDFText>
+            {formatUrl(url) ? (
+              <ResumePDFLink src={formatUrl(url)} isPDF={isPDF}>
+                <ResumePDFText bold={true}>{project}</ResumePDFText>
+              </ResumePDFLink>
+            ) : (
+              <ResumePDFText>{project}</ResumePDFText>
+            )}
             <ResumePDFText>{date}</ResumePDFText>
           </View>
           <View style={{ ...styles.flexCol, marginTop: spacing["0.5"] }}>

--- a/src/app/components/Resume/ResumePDF/common/utils.ts
+++ b/src/app/components/Resume/ResumePDF/common/utils.ts
@@ -1,0 +1,27 @@
+/**
+ * Formats a URL string to ensure it has a valid protocol.
+ * 
+ * @param input - The URL string to format
+ * @returns A properly formatted URL string:
+ * - Returns empty string if input is undefined or invalid
+ * - Returns the full URL if input is a valid URL
+ * - Adds 'https://' prefix for simple domain names (e.g., 'example.com')
+ */
+export function formatUrl(input: string | undefined): string {
+    if (!input) {
+        return '';
+    }
+
+    const trimmedInput = input.trim();
+
+    try {
+        const url = new URL(trimmedInput);
+        return url.href;
+    } catch (error) {
+        if (/^[a-zA-Z0-9-]+\.[a-zA-Z]{2,}$/.test(trimmedInput)) {
+            return `https://${trimmedInput}`;
+        }
+    }
+
+    return '';
+}

--- a/src/app/components/Resume/ResumePDF/index.tsx
+++ b/src/app/components/Resume/ResumePDF/index.tsx
@@ -72,6 +72,7 @@ export const ResumePDF = ({
         heading={formToHeading["projects"]}
         projects={projects}
         themeColor={themeColor}
+        isPDF={isPDF}
       />
     ),
     skills: () => (

--- a/src/app/components/ResumeForm/ProjectsForm.tsx
+++ b/src/app/components/ResumeForm/ProjectsForm.tsx
@@ -15,7 +15,7 @@ export const ProjectsForm = () => {
 
   return (
     <Form form="projects" addButtonText="Add Project">
-      {projects.map(({ project, date, descriptions }, idx) => {
+      {projects.map(({ project, date, descriptions, url }, idx) => {
         const handleProjectChange = (
           ...[
             field,
@@ -52,6 +52,14 @@ export const ProjectsForm = () => {
               value={date}
               onChange={handleProjectChange}
               labelClassName="col-span-2"
+            />
+            <Input
+              name="url"
+              label="Project URL"
+              placeholder="Enter a valid URL"
+              value={url}
+              onChange={handleProjectChange}
+              labelClassName="col-span-full"
             />
             <BulletListTextarea
               name="descriptions"

--- a/src/app/lib/redux/resumeSlice.ts
+++ b/src/app/lib/redux/resumeSlice.ts
@@ -39,6 +39,7 @@ export const initialProject: ResumeProject = {
   project: "",
   date: "",
   descriptions: [],
+  url: ""
 };
 
 export const initialFeaturedSkill: FeaturedSkill = { skill: "", rating: 4 };

--- a/src/app/lib/redux/types.ts
+++ b/src/app/lib/redux/types.ts
@@ -26,6 +26,7 @@ export interface ResumeProject {
   project: string;
   date: string;
   descriptions: string[];
+  url: string;
 }
 
 export interface FeaturedSkill {


### PR DESCRIPTION
## Detailed description of what was changed and why:
- Added support for adding links in the PDF
- Users can simply provide a valid project URL and the project name will be highlighted and a link will be attached to the project name field.
- There was a bug because of which after changing ny field it wasn't reflected in the PDF. For this I've passed document instance to update PDF hook.

## Related issues:
Closes #101 