### PR TITLE
Route to `resume-import` when clicking the "Builder" navbar item.

### DIFF
--- a/src/app/components/TopNavBar.tsx
+++ b/src/app/components/TopNavBar.tsx
@@ -32,7 +32,7 @@ export const TopNavBar = () => {
           className="flex items-center gap-2 text-sm font-medium"
         >
           {[
-            ["/resume-builder", "Builder"],
+            ["/resume-import", "Builder"],
             ["/resume-parser", "Parser"],
           ].map(([href, text]) => (
             <Link


### PR DESCRIPTION
Since the `resume-import` endpoint allows one to both import and create a resume from scratch, it makes more sense for the "Builder" navigation item to route to it.