### PR TITLE
feature: add github and demo links to projects section

### DIFF
--- a/src/app/components/Resume/ResumePDF/ResumePDFProject.tsx
+++ b/src/app/components/Resume/ResumePDF/ResumePDFProject.tsx
@@ -11,12 +11,10 @@ export const ResumePDFProject = ({
   heading,
   projects,
   themeColor,
-  isPreview = false,
 }: {
   heading: string;
   projects: ResumeProject[];
   themeColor: string;
-  isPreview?: boolean;
 }) => {
   if (projects.length === 0) {
     return null;
@@ -30,24 +28,20 @@ export const ResumePDFProject = ({
           project={project}
           themeColor={themeColor}
           isFirst={idx === 0}
-          isPreview={isPreview}
         />
       ))}
     </ResumePDFSection>
   );
 };
 
-
 const ProjectEntry = ({
   project,
   themeColor,
   isFirst,
-  isPreview,
 }: {
   project: ResumeProject;
   themeColor: string;
   isFirst: boolean;
-  isPreview: boolean;
 }) => {
   const {
     project: projectName,
@@ -66,7 +60,6 @@ const ProjectEntry = ({
             github={github}
             demo={demo}
             themeColor={themeColor}
-            isPreview={isPreview}
           />
         </View>
         <ResumePDFText>{date}</ResumePDFText>
@@ -82,12 +75,10 @@ const ProjectLinks = ({
   github,
   demo,
   themeColor,
-  isPreview,
 }: {
   github?: string;
   demo?: string;
   themeColor: string;
-  isPreview: boolean;
 }) => {
   if (!github && !demo) {
     return null;
@@ -110,27 +101,21 @@ const ProjectLinks = ({
         marginLeft: spacing["1"],
       }}
     >
-      {github &&
-        (isPreview ? (
+      {github && (
+        <Link src={ensureUrlHasProtocol(github)}>
           <Text style={linkStyle}>Github</Text>
-        ) : (
-          <Link src={ensureUrlHasProtocol(github)}>
-            <Text style={linkStyle}>Github</Text>
-          </Link>
-        ))}
+        </Link>
+      )}
 
       {github && demo && (
         <Text style={{ marginHorizontal: spacing["0.5"] }}></Text>
       )}
 
-      {demo &&
-        (isPreview ? (
+      {demo && (
+        <Link src={ensureUrlHasProtocol(demo)}>
           <Text style={linkStyle}>Demo</Text>
-        ) : (
-          <Link src={ensureUrlHasProtocol(demo)}>
-            <Text style={linkStyle}>Demo</Text>
-          </Link>
-        ))}
+        </Link>
+      )}
     </View>
   );
 };

--- a/src/app/components/Resume/ResumePDF/ResumePDFProject.tsx
+++ b/src/app/components/Resume/ResumePDF/ResumePDFProject.tsx
@@ -1,4 +1,4 @@
-import { View } from "@react-pdf/renderer";
+import { View, Link, Text } from "@react-pdf/renderer";
 import {
   ResumePDFSection,
   ResumePDFBulletList,
@@ -11,29 +11,126 @@ export const ResumePDFProject = ({
   heading,
   projects,
   themeColor,
+  isPreview = false,
 }: {
   heading: string;
   projects: ResumeProject[];
   themeColor: string;
+  isPreview?: boolean;
 }) => {
+  if (projects.length === 0) {
+    return null;
+  }
+
   return (
     <ResumePDFSection themeColor={themeColor} heading={heading}>
-      {projects.map(({ project, date, descriptions }, idx) => (
-        <View key={idx}>
-          <View
-            style={{
-              ...styles.flexRowBetween,
-              marginTop: spacing["0.5"],
-            }}
-          >
-            <ResumePDFText bold={true}>{project}</ResumePDFText>
-            <ResumePDFText>{date}</ResumePDFText>
-          </View>
-          <View style={{ ...styles.flexCol, marginTop: spacing["0.5"] }}>
-            <ResumePDFBulletList items={descriptions} />
-          </View>
-        </View>
+      {projects.map((project, idx) => (
+        <ProjectEntry
+          key={idx}
+          project={project}
+          themeColor={themeColor}
+          isFirst={idx === 0}
+          isPreview={isPreview}
+        />
       ))}
     </ResumePDFSection>
+  );
+};
+
+
+const ProjectEntry = ({
+  project,
+  themeColor,
+  isFirst,
+  isPreview,
+}: {
+  project: ResumeProject;
+  themeColor: string;
+  isFirst: boolean;
+  isPreview: boolean;
+}) => {
+  const {
+    project: projectName,
+    date,
+    descriptions,
+    github,
+    demo,
+  } = project;
+
+  return (
+    <View style={{ marginTop: isFirst ? 0 : spacing["0.5"] }}>
+      <View style={styles.flexRowBetween}>
+        <View style={{ ...styles.flexRow, alignItems: "center" }}>
+          <ResumePDFText bold={true}>{projectName}</ResumePDFText>
+          <ProjectLinks
+            github={github}
+            demo={demo}
+            themeColor={themeColor}
+            isPreview={isPreview}
+          />
+        </View>
+        <ResumePDFText>{date}</ResumePDFText>
+      </View>
+      <View style={{ ...styles.flexCol, marginTop: spacing["0.5"] }}>
+        <ResumePDFBulletList items={descriptions} />
+      </View>
+    </View>
+  );
+};
+
+const ProjectLinks = ({
+  github,
+  demo,
+  themeColor,
+  isPreview,
+}: {
+  github?: string;
+  demo?: string;
+  themeColor: string;
+  isPreview: boolean;
+}) => {
+  if (!github && !demo) {
+    return null;
+  }
+
+  const ensureUrlHasProtocol = (url: string) => {
+    if (!url.startsWith("http://") && !url.startsWith("https://")) {
+      return `https://${url}`;
+    }
+    return url;
+  };
+
+  const linkStyle = { color: themeColor };
+
+  return (
+    <View
+      style={{
+        ...styles.flexRow,
+        alignItems: "center",
+        marginLeft: spacing["1"],
+      }}
+    >
+      {github &&
+        (isPreview ? (
+          <Text style={linkStyle}>Github</Text>
+        ) : (
+          <Link src={ensureUrlHasProtocol(github)}>
+            <Text style={linkStyle}>Github</Text>
+          </Link>
+        ))}
+
+      {github && demo && (
+        <Text style={{ marginHorizontal: spacing["0.5"] }}></Text>
+      )}
+
+      {demo &&
+        (isPreview ? (
+          <Text style={linkStyle}>Demo</Text>
+        ) : (
+          <Link src={ensureUrlHasProtocol(demo)}>
+            <Text style={linkStyle}>Demo</Text>
+          </Link>
+        ))}
+    </View>
   );
 };

--- a/src/app/components/Resume/ResumePDF/index.tsx
+++ b/src/app/components/Resume/ResumePDF/index.tsx
@@ -72,6 +72,7 @@ export const ResumePDF = ({
         heading={formToHeading["projects"]}
         projects={projects}
         themeColor={themeColor}
+        isPreview={!isPDF}
       />
     ),
     skills: () => (

--- a/src/app/components/ResumeForm/ProjectsForm.tsx
+++ b/src/app/components/ResumeForm/ProjectsForm.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import { Form, FormSection } from "components/ResumeForm/Form";
 import {
   Input,
@@ -15,55 +16,98 @@ export const ProjectsForm = () => {
 
   return (
     <Form form="projects" addButtonText="Add Project">
-      {projects.map(({ project, date, descriptions }, idx) => {
-        const handleProjectChange = (
-          ...[
-            field,
-            value,
-          ]: CreateHandleChangeArgsWithDescriptions<ResumeProject>
-        ) => {
-          dispatch(changeProjects({ idx, field, value } as any));
-        };
-        const showMoveUp = idx !== 0;
-        const showMoveDown = idx !== projects.length - 1;
-
-        return (
-          <FormSection
-            key={idx}
-            form="projects"
-            idx={idx}
-            showMoveUp={showMoveUp}
-            showMoveDown={showMoveDown}
-            showDelete={showDelete}
-            deleteButtonTooltipText={"Delete project"}
-          >
-            <Input
-              name="project"
-              label="Project Name"
-              placeholder="OpenResume"
-              value={project}
-              onChange={handleProjectChange}
-              labelClassName="col-span-4"
-            />
-            <Input
-              name="date"
-              label="Date"
-              placeholder="Winter 2022"
-              value={date}
-              onChange={handleProjectChange}
-              labelClassName="col-span-2"
-            />
-            <BulletListTextarea
-              name="descriptions"
-              label="Description"
-              placeholder="Bullet points"
-              value={descriptions}
-              onChange={handleProjectChange}
-              labelClassName="col-span-full"
-            />
-          </FormSection>
-        );
-      })}
+      {projects.map((project, idx) => (
+        <ProjectFormSection
+          key={idx}
+          project={project}
+          idx={idx}
+          showDelete={showDelete}
+          showMoveUp={idx !== 0}
+          showMoveDown={idx !== projects.length - 1}
+        />
+      ))}
     </Form>
+  );
+};
+
+const ProjectFormSection = ({
+  project,
+  idx,
+  showDelete,
+  showMoveUp,
+  showMoveDown,
+}: {
+  project: ResumeProject;
+  idx: number;
+  showDelete: boolean;
+  showMoveUp: boolean;
+  showMoveDown: boolean;
+}) => {
+  const {
+    project: projectName,
+    date,
+    descriptions,
+    github,
+    demo,
+  } = project;
+  const dispatch = useAppDispatch();
+
+  const handleProjectChange = useCallback(
+    (...[field, value]: CreateHandleChangeArgsWithDescriptions<ResumeProject>) => {
+      dispatch(changeProjects({ idx, field, value } as any));
+    },
+    [dispatch, idx]
+  );
+
+  return (
+    <FormSection
+      form="projects"
+      idx={idx}
+      showMoveUp={showMoveUp}
+      showMoveDown={showMoveDown}
+      showDelete={showDelete}
+      deleteButtonTooltipText="Delete project"
+    >
+      <Input
+        name="project"
+        label="Project Name"
+        placeholder="OpenResume"
+        value={projectName}
+        onChange={handleProjectChange}
+        labelClassName="col-span-4"
+      />
+      <Input
+        name="date"
+        label="Date"
+        placeholder="Winter 2022"
+        value={date}
+        onChange={handleProjectChange}
+        labelClassName="col-span-2"
+      />
+      <Input
+        name="github"
+        label="GitHub"
+        placeholder="github.com/user/repo"
+        value={github}
+        onChange={handleProjectChange}
+        labelClassName="col-span-3"
+      />
+      <Input
+        name="demo"
+        label="Demo"
+        placeholder="user.github.io/repo"
+        value={demo}
+        onChange={handleProjectChange}
+        labelClassName="col-span-3"
+      />
+      <BulletListTextarea
+        name="descriptions"
+        label="Description"
+        placeholder="Bullet points"
+        value={descriptions}
+        onChange={handleProjectChange}
+        labelClassName="col-span-full"
+      />
+    </FormSection>
   );
 };

--- a/src/app/lib/redux/resumeSlice.ts
+++ b/src/app/lib/redux/resumeSlice.ts
@@ -39,6 +39,8 @@ export const initialProject: ResumeProject = {
   project: "",
   date: "",
   descriptions: [],
+  github: "",
+  demo: "",
 };
 
 export const initialFeaturedSkill: FeaturedSkill = { skill: "", rating: 4 };

--- a/src/app/lib/redux/types.ts
+++ b/src/app/lib/redux/types.ts
@@ -26,6 +26,8 @@ export interface ResumeProject {
   project: string;
   date: string;
   descriptions: string[];
+  github?: string;
+  demo?: string;
 }
 
 export interface FeaturedSkill {


### PR DESCRIPTION
### Description

This pull request enhances the "Projects" section by adding two new optional fields: "Github" and "Demo." This feature empowers users to provide direct links to their project repositories and live applications, offering a more complete and interactive view of their work for recruiters and hiring managers.

### Key Changes

* **Expanded Data Model:**
    * The `ResumeProject` type in `src/app/lib/redux/types.ts` has been updated to include optional `github` and `demo` string properties.
    * The corresponding initial state in `src/app/lib/redux/resumeSlice.ts` has been updated to reflect these new fields.
* **Enhanced User Interface:**
    * The `ProjectsForm.tsx` component now includes two new input fields, allowing users to easily add their GitHub repository and demo URLs.
* **Dynamic PDF and Preview Rendering:**
    * The `ResumePDFProject.tsx` component has been refactored to intelligently render the new links.
    * It now displays the project name followed by "Github" and "Demo" links in a clean, easy-to-read format (e.g., `Project Name Github - Demo`).
    * A custom solution has been implemented to ensure the links are correctly displayed in the live preview while remaining fully clickable in the final downloaded PDF.

### How to Verify

1.  Navigate to the "Projects" section in the resume builder.
2.  Add a new project and fill out the new "Github" and "Demo" fields with valid URLs.
3.  Download the resume as a PDF.
4.  Open the PDF and click on the "Github" and "Demo" links to ensure they navigate to the correct URLs.