### PR TITLE
feat: implement resume configuration save/load 

### DIFF
--- a/src/app/components/Resume/ResumeControlBar.tsx
+++ b/src/app/components/Resume/ResumeControlBar.tsx
@@ -7,6 +7,7 @@ import {
 } from "@heroicons/react/24/outline";
 import { usePDF } from "@react-pdf/renderer";
 import dynamic from "next/dynamic";
+import { Resume } from "lib/redux/types";
 
 const ResumeControlBar = ({
   scale,
@@ -14,12 +15,15 @@ const ResumeControlBar = ({
   documentSize,
   document,
   fileName,
+  resume,
 }: {
+
   scale: number;
   setScale: (scale: number) => void;
   documentSize: string;
   document: JSX.Element;
   fileName: string;
+  resume: Resume;
 }) => {
   const { scaleOnResize, setScaleOnResize } = useSetDefaultScale({
     setScale,
@@ -65,7 +69,18 @@ const ResumeControlBar = ({
         download={fileName}
       >
         <ArrowDownTrayIcon className="h-4 w-4" />
-        <span className="whitespace-nowrap">Download Resume</span>
+        <span className="whitespace-nowrap">Download Resume as PDF</span>
+      </a>
+      <a
+        className="ml-1 flex items-center gap-1 rounded-md border border-gray-300 px-3 py-0.5 hover:bg-gray-100 lg:ml-8"
+
+        href={`data:text/json;charset=utf-8,${encodeURIComponent(
+          JSON.stringify(resume, null, 2)
+        )}`}
+        download={`${fileName}.json`}
+      >
+        <ArrowDownTrayIcon className="h-4 w-4" />
+        <span className="whitespace-nowrap">Download Resume as JSON</span>
       </a>
     </div>
   );

--- a/src/app/components/Resume/ResumeControlBar.tsx
+++ b/src/app/components/Resume/ResumeControlBar.tsx
@@ -1,9 +1,10 @@
 "use client";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useSetDefaultScale } from "components/Resume/hooks";
 import {
   MagnifyingGlassIcon,
   ArrowDownTrayIcon,
+  ArrowUpTrayIcon,
 } from "@heroicons/react/24/outline";
 import { usePDF } from "@react-pdf/renderer";
 import dynamic from "next/dynamic";
@@ -16,7 +17,9 @@ const ResumeControlBar = ({
   document,
   fileName,
   resume,
+  setResume,
 }: {
+
 
   scale: number;
   setScale: (scale: number) => void;
@@ -24,6 +27,7 @@ const ResumeControlBar = ({
   document: JSX.Element;
   fileName: string;
   resume: Resume;
+  setResume: (resume: Resume) => void;
 }) => {
   const { scaleOnResize, setScaleOnResize } = useSetDefaultScale({
     setScale,
@@ -36,6 +40,28 @@ const ResumeControlBar = ({
   useEffect(() => {
     update();
   }, [update, document]);
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleImport = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    const reader = new FileReader();
+
+    reader.onload = (e) => {
+      try {
+        const json = JSON.parse(e.target?.result as string);
+        setResume(json);
+      } catch (error) {
+        console.error("Failed to parse resume JSON:", error);
+      }
+    };
+
+    reader.readAsText(file);
+    // Reset input so the same file can be selected again if needed
+    event.target.value = "";
+  };
 
   return (
     <div className="sticky bottom-0 left-0 right-0 flex h-[var(--resume-control-bar-height)] items-center justify-center px-[var(--resume-padding)] text-gray-600 lg:justify-between">
@@ -73,7 +99,6 @@ const ResumeControlBar = ({
       </a>
       <a
         className="ml-1 flex items-center gap-1 rounded-md border border-gray-300 px-3 py-0.5 hover:bg-gray-100 lg:ml-8"
-
         href={`data:text/json;charset=utf-8,${encodeURIComponent(
           JSON.stringify(resume, null, 2)
         )}`}
@@ -82,6 +107,17 @@ const ResumeControlBar = ({
         <ArrowDownTrayIcon className="h-4 w-4" />
         <span className="whitespace-nowrap">Download Resume as JSON</span>
       </a>
+      <label className="ml-1 flex cursor-pointer items-center gap-1 rounded-md border border-gray-300 px-3 py-0.5 hover:bg-gray-100 lg:ml-2">
+        <ArrowUpTrayIcon className="h-4 w-4" />
+        <span className="whitespace-nowrap">Import from JSON</span>
+        <input
+          ref={fileInputRef}
+          type="file"
+          className="hidden"
+          accept=".json"
+          onChange={handleImport}
+        />
+      </label>
     </div>
   );
 };

--- a/src/app/components/Resume/ResumeControlBar.tsx
+++ b/src/app/components/Resume/ResumeControlBar.tsx
@@ -104,43 +104,37 @@ const ResumeControlBar = ({
       </div>
 
       <div className="flex items-center gap-2 sm:gap-4">
-        <div className="flex items-center gap-2 border-r border-gray-200 pr-2 sm:pr-4">
-          <a
-            className="flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-100 hover:text-gray-900 transition-colors"
-            href={instance.url!}
-            download={fileName}
-            title="Download PDF"
-          >
-            <ArrowDownTrayIcon className="h-4 w-4" />
-            <span className="hidden sm:inline">PDF</span>
-          </a>
-        </div>
+        <a
+          className="ml-1 flex items-center gap-1 rounded-md border border-gray-300 px-3 py-0.5 hover:bg-gray-100 lg:ml-8"
+          href={instance.url!}
+          download={fileName}
+        >
+          <ArrowDownTrayIcon className="h-4 w-4" />
+          <span className="whitespace-nowrap">Download Resume</span>
+        </a>
 
-        <div className="flex items-center gap-2">
-          <a
-            className="flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-100 hover:text-gray-900 transition-colors"
-            href={`data:text/json;charset=utf-8,${encodeURIComponent(
-              JSON.stringify({ resume, settings }, null, 2)
-            )}`}
-            download={`${fileName}.json`}
-            title="Download JSON"
-          >
-            <ArrowDownTrayIcon className="h-4 w-4" />
-            <span className="hidden sm:inline">JSON</span>
-          </a>
+        <a
+          className="flex items-center gap-1 rounded-md border border-gray-300 px-3 py-0.5 hover:bg-gray-100"
+          href={`data:text/json;charset=utf-8,${encodeURIComponent(
+            JSON.stringify({ resume, settings }, null, 2)
+          )}`}
+          download={`${fileName}.json`}
+        >
+          <ArrowDownTrayIcon className="h-4 w-4" />
+          <span className="whitespace-nowrap">JSON</span>
+        </a>
 
-          <label className="flex cursor-pointer items-center gap-1.5 rounded-md bg-gray-900 px-3 py-1.5 text-sm font-medium text-white hover:bg-gray-700 transition-colors shadow-sm" title="Import JSON">
-            <ArrowUpTrayIcon className="h-4 w-4" />
-            <span className="hidden sm:inline">Import</span>
-            <input
-              ref={fileInputRef}
-              type="file"
-              className="hidden"
-              accept=".json"
-              onChange={handleImport}
-            />
-          </label>
-        </div>
+        <label className="flex cursor-pointer items-center gap-1 rounded-md border border-gray-300 px-3 py-0.5 hover:bg-gray-100">
+          <ArrowUpTrayIcon className="h-4 w-4" />
+          <span className="whitespace-nowrap">Import</span>
+          <input
+            ref={fileInputRef}
+            type="file"
+            className="hidden"
+            accept=".json"
+            onChange={handleImport}
+          />
+        </label>
       </div>
     </div>
   );

--- a/src/app/components/Resume/ResumeControlBar.tsx
+++ b/src/app/components/Resume/ResumeControlBar.tsx
@@ -64,60 +64,74 @@ const ResumeControlBar = ({
   };
 
   return (
-    <div className="sticky bottom-0 left-0 right-0 flex h-[var(--resume-control-bar-height)] items-center justify-center px-[var(--resume-padding)] text-gray-600 lg:justify-between">
-      <div className="flex items-center gap-2">
-        <MagnifyingGlassIcon className="h-5 w-5" aria-hidden="true" />
-        <input
-          type="range"
-          min={0.5}
-          max={1.5}
-          step={0.01}
-          value={scale}
-          onChange={(e) => {
-            setScaleOnResize(false);
-            setScale(Number(e.target.value));
-          }}
-        />
-        <div className="w-10">{`${Math.round(scale * 100)}%`}</div>
-        <label className="hidden items-center gap-1 lg:flex">
+    <div className="sticky bottom-0 left-0 right-0 flex h-[var(--resume-control-bar-height)] items-center justify-between px-[var(--resume-padding)] bg-white/90 backdrop-blur-sm border-t border-gray-200 text-gray-600 z-10">
+      <div className="flex items-center gap-4">
+        <div className="flex items-center gap-2">
+          <MagnifyingGlassIcon className="h-5 w-5 text-gray-400" aria-hidden="true" />
+          <input
+            type="range"
+            min={0.5}
+            max={1.5}
+            step={0.01}
+            value={scale}
+            className="h-1 w-24 cursor-pointer appearance-none rounded-lg bg-gray-200 accent-blue-600 hover:bg-gray-300"
+            onChange={(e) => {
+              setScaleOnResize(false);
+              setScale(Number(e.target.value));
+            }}
+          />
+          <div className="w-12 text-sm font-medium">{`${Math.round(scale * 100)}%`}</div>
+        </div>
+        <label className="hidden items-center gap-1.5 lg:flex cursor-pointer select-none text-sm text-gray-500 hover:text-gray-900">
           <input
             type="checkbox"
-            className="mt-0.5 h-4 w-4"
+            className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
             checked={scaleOnResize}
             onChange={() => setScaleOnResize((prev) => !prev)}
           />
-          <span className="select-none">Autoscale</span>
+          <span>Autoscale</span>
         </label>
       </div>
-      <a
-        className="ml-1 flex items-center gap-1 rounded-md border border-gray-300 px-3 py-0.5 hover:bg-gray-100 lg:ml-8"
-        href={instance.url!}
-        download={fileName}
-      >
-        <ArrowDownTrayIcon className="h-4 w-4" />
-        <span className="whitespace-nowrap">Download Resume as PDF</span>
-      </a>
-      <a
-        className="ml-1 flex items-center gap-1 rounded-md border border-gray-300 px-3 py-0.5 hover:bg-gray-100 lg:ml-8"
-        href={`data:text/json;charset=utf-8,${encodeURIComponent(
-          JSON.stringify(resume, null, 2)
-        )}`}
-        download={`${fileName}.json`}
-      >
-        <ArrowDownTrayIcon className="h-4 w-4" />
-        <span className="whitespace-nowrap">Download Resume as JSON</span>
-      </a>
-      <label className="ml-1 flex cursor-pointer items-center gap-1 rounded-md border border-gray-300 px-3 py-0.5 hover:bg-gray-100 lg:ml-2">
-        <ArrowUpTrayIcon className="h-4 w-4" />
-        <span className="whitespace-nowrap">Import from JSON</span>
-        <input
-          ref={fileInputRef}
-          type="file"
-          className="hidden"
-          accept=".json"
-          onChange={handleImport}
-        />
-      </label>
+
+      <div className="flex items-center gap-2 sm:gap-4">
+        <div className="flex items-center gap-2 border-r border-gray-200 pr-2 sm:pr-4">
+          <a
+            className="flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-100 hover:text-gray-900 transition-colors"
+            href={instance.url!}
+            download={fileName}
+            title="Download PDF"
+          >
+            <ArrowDownTrayIcon className="h-4 w-4" />
+            <span className="hidden sm:inline">PDF</span>
+          </a>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <a
+            className="flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-100 hover:text-gray-900 transition-colors"
+            href={`data:text/json;charset=utf-8,${encodeURIComponent(
+              JSON.stringify(resume, null, 2)
+            )}`}
+            download={`${fileName}.json`}
+            title="Download JSON"
+          >
+            <ArrowDownTrayIcon className="h-4 w-4" />
+            <span className="hidden sm:inline">JSON</span>
+          </a>
+
+          <label className="flex cursor-pointer items-center gap-1.5 rounded-md bg-gray-900 px-3 py-1.5 text-sm font-medium text-white hover:bg-gray-700 transition-colors shadow-sm" title="Import JSON">
+            <ArrowUpTrayIcon className="h-4 w-4" />
+            <span className="hidden sm:inline">Import</span>
+            <input
+              ref={fileInputRef}
+              type="file"
+              className="hidden"
+              accept=".json"
+              onChange={handleImport}
+            />
+          </label>
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/app/components/Resume/ResumeControlBar.tsx
+++ b/src/app/components/Resume/ResumeControlBar.tsx
@@ -9,6 +9,7 @@ import {
 import { usePDF } from "@react-pdf/renderer";
 import dynamic from "next/dynamic";
 import { Resume } from "lib/redux/types";
+import { Settings } from "lib/redux/settingsSlice";
 
 const ResumeControlBar = ({
   scale,
@@ -18,6 +19,8 @@ const ResumeControlBar = ({
   fileName,
   resume,
   setResume,
+  settings,
+  setSettings,
 }: {
 
 
@@ -28,6 +31,8 @@ const ResumeControlBar = ({
   fileName: string;
   resume: Resume;
   setResume: (resume: Resume) => void;
+  settings: Settings;
+  setSettings: (settings: Settings) => void;
 }) => {
   const { scaleOnResize, setScaleOnResize } = useSetDefaultScale({
     setScale,
@@ -52,7 +57,12 @@ const ResumeControlBar = ({
     reader.onload = (e) => {
       try {
         const json = JSON.parse(e.target?.result as string);
-        setResume(json);
+        if (json.resume && json.settings) {
+          setResume(json.resume);
+          setSettings(json.settings);
+        } else {
+          setResume(json);
+        }
       } catch (error) {
         console.error("Failed to parse resume JSON:", error);
       }
@@ -110,7 +120,7 @@ const ResumeControlBar = ({
           <a
             className="flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-100 hover:text-gray-900 transition-colors"
             href={`data:text/json;charset=utf-8,${encodeURIComponent(
-              JSON.stringify(resume, null, 2)
+              JSON.stringify({ resume, settings }, null, 2)
             )}`}
             download={`${fileName}.json`}
             title="Download JSON"

--- a/src/app/components/Resume/ResumeControlBar.tsx
+++ b/src/app/components/Resume/ResumeControlBar.tsx
@@ -108,6 +108,7 @@ const ResumeControlBar = ({
           className="ml-1 flex items-center gap-1 rounded-md border border-gray-300 px-3 py-0.5 hover:bg-gray-100 lg:ml-8"
           href={instance.url!}
           download={fileName}
+          title="Download PDF"
         >
           <ArrowDownTrayIcon className="h-4 w-4" />
           <span className="whitespace-nowrap">Download Resume</span>
@@ -119,14 +120,15 @@ const ResumeControlBar = ({
             JSON.stringify({ resume, settings }, null, 2)
           )}`}
           download={`${fileName}.json`}
+          title="Download Config"
         >
           <ArrowDownTrayIcon className="h-4 w-4" />
-          <span className="whitespace-nowrap">JSON</span>
+          <span className="whitespace-nowrap">Config</span>
         </a>
 
-        <label className="flex cursor-pointer items-center gap-1 rounded-md border border-gray-300 px-3 py-0.5 hover:bg-gray-100">
+        <label className="flex cursor-pointer items-center gap-1 rounded-md border border-gray-300 px-3 py-0.5 hover:bg-gray-100" title="Import Config">
           <ArrowUpTrayIcon className="h-4 w-4" />
-          <span className="whitespace-nowrap">Import</span>
+          <span className="whitespace-nowrap">Import Config</span>
           <input
             ref={fileInputRef}
             type="file"

--- a/src/app/components/Resume/index.tsx
+++ b/src/app/components/Resume/index.tsx
@@ -7,9 +7,10 @@ import {
   ResumeControlBarBorder,
 } from "components/Resume/ResumeControlBar";
 import { FlexboxSpacer } from "components/FlexboxSpacer";
-import { useAppSelector } from "lib/redux/hooks";
-import { selectResume } from "lib/redux/resumeSlice";
+import { useAppSelector, useAppDispatch } from "lib/redux/hooks";
+import { selectResume, setResume } from "lib/redux/resumeSlice";
 import { selectSettings } from "lib/redux/settingsSlice";
+import { Resume as ResumeType } from "lib/redux/types";
 import { DEBUG_RESUME_PDF_FLAG } from "lib/constants";
 import {
   useRegisterReactPDFFont,
@@ -21,6 +22,7 @@ export const Resume = () => {
   const [scale, setScale] = useState(0.8);
   const resume = useAppSelector(selectResume);
   const settings = useAppSelector(selectSettings);
+  const dispatch = useAppDispatch();
   const document = useMemo(
     () => <ResumePDF resume={resume} settings={settings} isPDF={true} />,
     [resume, settings]
@@ -55,6 +57,7 @@ export const Resume = () => {
             document={document}
             fileName={resume.profile.name + " - Resume"}
             resume={resume}
+            setResume={(newResume: ResumeType) => dispatch(setResume(newResume))}
           />
         </div>
         <ResumeControlBarBorder />

--- a/src/app/components/Resume/index.tsx
+++ b/src/app/components/Resume/index.tsx
@@ -9,8 +9,10 @@ import {
 import { FlexboxSpacer } from "components/FlexboxSpacer";
 import { useAppSelector, useAppDispatch } from "lib/redux/hooks";
 import { selectResume, setResume } from "lib/redux/resumeSlice";
-import { selectSettings } from "lib/redux/settingsSlice";
-import { Resume as ResumeType } from "lib/redux/types";
+import { selectSettings, setSettings, Settings as SettingsType } from "lib/redux/settingsSlice";
+import {
+  Resume as ResumeType,
+} from "lib/redux/types";
 import { DEBUG_RESUME_PDF_FLAG } from "lib/constants";
 import {
   useRegisterReactPDFFont,
@@ -58,6 +60,10 @@ export const Resume = () => {
             fileName={resume.profile.name + " - Resume"}
             resume={resume}
             setResume={(newResume: ResumeType) => dispatch(setResume(newResume))}
+            settings={settings}
+            setSettings={(newSettings: SettingsType) =>
+              dispatch(setSettings(newSettings))
+            }
           />
         </div>
         <ResumeControlBarBorder />

--- a/src/app/components/Resume/index.tsx
+++ b/src/app/components/Resume/index.tsx
@@ -54,6 +54,7 @@ export const Resume = () => {
             documentSize={settings.documentSize}
             document={document}
             fileName={resume.profile.name + " - Resume"}
+            resume={resume}
           />
         </div>
         <ResumeControlBarBorder />


### PR DESCRIPTION
I added a feature that allows users to save and reuse their resume as a configuration.

In `ResumeControlBar.tsx`, I introduced two new buttons:

* **Download Config** : exports the current resume configuration
* **Load Config** : imports a previously saved configuration

Both actions are working as expected.

If you have any suggestions or would like changes made, let me know and I’ll be happy to update it.

<img width="900" height="131" alt="image" src="https://github.com/user-attachments/assets/0acf265c-daed-4650-a9e5-4caf2f02c40c" />
